### PR TITLE
Example of custom attribute during customer creation

### DIFF
--- a/create_customer.php
+++ b/create_customer.php
@@ -7,8 +7,11 @@
   $site_id = 'YOUR-SITE-ID';
   $api_key = 'YOUR-API-KEY';
 
-  $data = array("email" => "test@example.com", "created_at" => time());
-  // Creates or updates a user with the ID 1337, email test@example.com and a created_at timestamp
+  $data = array("email" => "test@example.com", "created_at" => time(), "custom_attribute" => "custom_attribute_value");
+  // Creates or updates a user with the ID prod_1337, email test@example.com and a created_at timestamp.
+  // email and created_at are mandatory
+  // Any number of optional custom attributes can be passed as key-value pairs. 
+  //     You can pass any other information that would be useful in your triggers.
 
   curl_setopt($session, CURLOPT_URL, $customerio_url.$customer_id);
   curl_setopt($session, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);


### PR DESCRIPTION
There is a little inconsistency in the API, for example, when tracking an event, you put the custom event attributes in a 'data' parameter. But when creating a customer, they go at the same level as the email and created_at.

This is counter-intuitive, so an example of using custom attributes at customer creation would be helpful.
