### PR TITLE
Fix doc URLs to canonical docs.customer.io domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ This repo contained two PHP example scripts written in 2013. It was never an off
 
 For PHP integrations with Customer.io today, call the REST API directly using the HTTP client of your choice (Guzzle, Symfony HttpClient, the `curl` extension, etc.).
 
-- API reference: https://customer.io/docs/api/
-- Track API guide: https://customer.io/docs/journeys/track-api/
+- API reference: https://docs.customer.io/api/
+- Track API guide: https://docs.customer.io/integrations/api/track/
+- Pipelines (CDP) vs Track API: https://docs.customer.io/integrations/api/track-vs-cdp-api/
 
 If you need help integrating PHP, contact your Customer.io account team or reach out to support.
 
@@ -22,7 +23,7 @@ Customer.io maintains client libraries for these languages:
 - **Ruby**: https://github.com/customerio/customerio-ruby
 - **Go**: https://github.com/customerio/go-customerio
 
-Mobile SDKs (iOS, Android, React Native, Flutter, Expo) are listed at https://customer.io/docs/sdk/.
+Mobile SDKs (iOS, Android, React Native, Flutter, Expo) are also available; see the [Customer.io org on GitHub](https://github.com/customerio).
 
 ## Why the change
 


### PR DESCRIPTION
Follow-up to #6. The `customer.io/docs/*` URLs in the deprecation README either 308-redirect (`/docs/api/`) or 404 (`/docs/journeys/track-api/`, `/docs/sdk/`).

Changes:
- `https://customer.io/docs/api/` -> `https://docs.customer.io/api/`
- `https://customer.io/docs/journeys/track-api/` -> `https://docs.customer.io/integrations/api/track/` (the broken one was 404)
- Added `https://docs.customer.io/integrations/api/track-vs-cdp-api/` so PHP integrators see Pipelines as an option, since that's now the recommended path for CDP-style usage.
- Replaced the broken `/docs/sdk/` link with the [customerio org on GitHub](https://github.com/customerio).

Land this before archiving the repo, since archived repos can't accept PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating links in `README.md`; no code or runtime behavior is affected.
> 
> **Overview**
> Updates the archived repo `README.md` to point PHP integrators to the canonical `docs.customer.io` URLs for the API reference and Track API guide, and adds a new link comparing Pipelines (CDP) vs Track API.
> 
> Replaces the previously referenced Mobile SDK docs link with a pointer to the Customer.io GitHub org for current SDKs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de6c98c0c079c0237c34064e5d50fb23e57d9a67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->